### PR TITLE
Fix NullPointerException after using ClearBuffer

### DIFF
--- a/Examples/ConsoleGameEngineExamples.csproj
+++ b/Examples/ConsoleGameEngineExamples.csproj
@@ -33,7 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>ConsoleGameEngineExamples.CaveGenerator</StartupObject>
+    <StartupObject>ConsoleGameEngineExamples.HelloWorld</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ConsoleGameEngine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -60,6 +60,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="caligraphy.flf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="README.md" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/ConsoleEngine.cs
+++ b/Source/ConsoleEngine.cs
@@ -138,8 +138,10 @@
 		public void ClearBuffer() {
 			/*Array.Clear(CharBuffer, 0, CharBuffer.Length);
 			Array.Clear(ColorBuffer, 0, ColorBuffer.Length);
-			Array.Clear(BackgroundBuffer, 0, BackgroundBuffer.Length);*/
-			Array.Clear(GlyphBuffer, 0, GlyphBuffer.Length);
+			Array.Clear(BackgroundBuffer, 0, BackgroundBuffer.Length);*/			
+			for (int y = 0; y < GlyphBuffer.GetLength(1); y++)
+				for (int x = 0; x < GlyphBuffer.GetLength(0); x++)
+					GlyphBuffer[x, y] = new Glyph();
 		}
 
 		/// <summary> Blits the screenbuffer to the Console window. </summary>

--- a/Source/ConsoleGameEngine.csproj
+++ b/Source/ConsoleGameEngine.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ConsoleHelper.cs" />
     <Compile Include="ConsolePalette.cs" />
     <Compile Include="FigletFont.cs" />
+    <Compile Include="Glyph.cs" />
     <Compile Include="Point.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility.cs" />


### PR DESCRIPTION
ClearBuffer is being cleared completely with this new GlyphBuffer array, which causes the engine to crash with NullPointerException with any SetPixel or similar after using it.

I know it's not the best way, but this PR also solves minor problems: Engine was not compiling at all, because of lack of Glyph.cs in the .csproj, and HelloWorld cannot run because FLF was not copied into the output directory automatically.