### PR TITLE
Huge memory consumption fixed for buffers and glyphs

### DIFF
--- a/Source/ConsoleEngine.cs
+++ b/Source/ConsoleEngine.cs
@@ -100,7 +100,7 @@
 		/// </summary>
 		/// <param name="selectedPoint"></param>
 		/// <returns></returns>
-		public Glyph PixelAt(Point selectedPoint)
+		public Glyph? PixelAt(Point selectedPoint)
 		{
 			if(selectedPoint.X > 0 && selectedPoint.X < GlyphBuffer.GetLength(0) && selectedPoint.Y > 0 && selectedPoint.Y < GlyphBuffer.GetLength(1))
 				return GlyphBuffer[selectedPoint.X, selectedPoint.Y];

--- a/Source/Glyph.cs
+++ b/Source/Glyph.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ConsoleGameEngine
 {
-	public class Glyph
+	public struct Glyph
 	{
 		public char c;
 		public int fg;


### PR DESCRIPTION
This is a great project. I was thinking for creating a tiny game for myself and found this. It's cool how performant it works (unlike .NET's default console). But I noticed some huge memory consumption, it turns out you use a reference type in a case where struct would perfectly fit.

I'm not familiar with your project well (and I don't see tests to run), but hope it will work (it worked for me and hugely decreases the memory consumption ; without this fix, it will consume gigabytes in a few seconds on an empty game with `.Construct(40, 40, 20, 20, FramerateMode.Unlimited)`).